### PR TITLE
Use alpine and particular use r-devel

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,8 @@
-FROM rocker/r-base
+FROM FROM docker.io/rhub/r-minimal:devel
 
-RUN apt-get -qq update && \
-  apt-get install -y --no-install-recommends git
+RUN apk update && \
+  apk add --no-cache git \
+  && echo 'options(repos="https://cloud.r-project.org")' >> /usr/local/lib/R/etc/Rprofile.site
 
 COPY DESCRIPTION .
 


### PR DESCRIPTION
Got rejected from CRAN -- realized the current image is not r-devel as I'd assumed!

Switching to this image as the rocker version of using r-devel is ostensibly much fussier.